### PR TITLE
use osm tools container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   database:
-    image: 'postgis/postgis'
+    image: 'postgis/postgis:latest'
     ports:
       - 55432:5432
     environment:
@@ -13,7 +13,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
   imposm:
-    image: 'golang'
+    image: 'dlimkin/osm-tools:latest'
     volumes:
       - .:/usr/local/imposm
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
-  imposm:
+  osm:
     image: 'dlimkin/osm-tools:latest'
     volumes:
       - .:/usr/local/imposm
+    tty: true
 
 volumes:
   db-data:


### PR DESCRIPTION
the osm tools docker image (w/ osm2pgsql and imposm) works great, no worries about relative paths to the imposm program. will simplify use of either method